### PR TITLE
CoILBaseline Sensor Bugfix

### DIFF
--- a/drive/CoILBaseline.py
+++ b/drive/CoILBaseline.py
@@ -140,30 +140,18 @@ class CoILBaseline(AutonomousAgent):
         return attentions
 
     def _process_sensors(self, sensor):
-
-        iteration = 0
-
-        sensor = sensor[g_conf.IMAGE_CUT[0]:g_conf.IMAGE_CUT[1], 0:3]
-
+        sensor = sensor[:, :, 0:3]  # BGRA->BRG drop alpha channel
+        sensor = sensor[:, :, ::-1]  # BGR->RGB
+        sensor = sensor[g_conf.IMAGE_CUT[0]:g_conf.IMAGE_CUT[1], :, :]  # crop
         sensor = scipy.misc.imresize(sensor, (g_conf.SENSORS['rgb'][1], g_conf.SENSORS['rgb'][2]))
-
         self.latest_image = sensor
 
         sensor = np.swapaxes(sensor, 0, 1)
-
         sensor = np.transpose(sensor, (2, 1, 0))
-
         sensor = torch.from_numpy(sensor / 255.0).type(torch.FloatTensor).cuda()
-
-        if iteration == 0:
-            image_input = sensor
-
-        iteration += 1
-
-        image_input = image_input.unsqueeze(0)
-
+        image_input = sensor.unsqueeze(0)
         self.latest_image_tensor = image_input
-        print ("SHAPE ", image_input.shape)
+
         return image_input
 
     def _get_current_direction(self, vehicle_position):


### PR DESCRIPTION
A recent commit truncated the second axis of `sensor` to `0:3`, but it's the third axis that is RGB channels (second axis is height). Additionally they need to be reversed since its BGRA not RGBA.

Where has this been tested?

    Platform(s): Ubuntu 18.04; Carla 0.9.5
    Python version(s): Python 3.5

Possible Drawbacks
