### PR TITLE
Fix training hours in model configurations.

### DIFF
--- a/configs/nocrash/resnet34imnet10-nospeed.yaml
+++ b/configs/nocrash/resnet34imnet10-nospeed.yaml
@@ -23,7 +23,7 @@ TRAIN_DATASET_NAME: 'CoILTrain'  # The name of the training dataset used. Must b
 AUGMENTATION: None  # The image augmentation applied on every input image
 DATA_USED: 'all'  # The part of the data to be used
 USE_NOISE_DATA: True  # If we use the noise data.
-NUMBER_OF_HOURS: 50  # Number of hours to be taken from the input data
+NUMBER_OF_HOURS: 10  # Number of hours to be taken from the input data
 
 #### Testing Related Parameters ####
 TEST_SCHEDULE: [2000, 100000]  # The frequency the model is actually tested.

--- a/configs/nocrash/resnet34imnet100-nospeed.yaml
+++ b/configs/nocrash/resnet34imnet100-nospeed.yaml
@@ -23,7 +23,7 @@ TRAIN_DATASET_NAME: 'CoILTrain'  # The name of the training dataset used. Must b
 AUGMENTATION: None  # The image augmentation applied on every input image
 DATA_USED: 'all'  # The part of the data to be used
 USE_NOISE_DATA: True  # If we use the noise data.
-NUMBER_OF_HOURS: 50  # Number of hours to be taken from the input data
+NUMBER_OF_HOURS: 100  # Number of hours to be taken from the input data
 
 #### Testing Related Parameters ####
 TEST_SCHEDULE: [2000, 100000]  # The frequency the model is actually tested.

--- a/configs/nocrash/resnet34imnet100.yaml
+++ b/configs/nocrash/resnet34imnet100.yaml
@@ -23,7 +23,7 @@ TRAIN_DATASET_NAME: 'CoILTrain'  # The name of the training dataset used. Must b
 AUGMENTATION: None  # The image augmentation applied on every input image
 DATA_USED: 'all'  # The part of the data to be used
 USE_NOISE_DATA: True  # If we use the noise data.
-NUMBER_OF_HOURS: 50  # Number of hours to be taken from the input data
+NUMBER_OF_HOURS: 100  # Number of hours to be taken from the input data
 
 #### Testing Related Parameters ####
 TEST_SCHEDULE: [2000, 100000]  # The frequency the model is actually tested.

--- a/configs/nocrash/resnet34imnet10S1.yaml
+++ b/configs/nocrash/resnet34imnet10S1.yaml
@@ -23,7 +23,7 @@ TRAIN_DATASET_NAME: 'CoILTrain'  # The name of the training dataset used. Must b
 AUGMENTATION: None  # The image augmentation applied on every input image
 DATA_USED: 'all'  # The part of the data to be used
 USE_NOISE_DATA: True  # If we use the noise data.
-NUMBER_OF_HOURS: 50  # Number of hours to be taken from the input data
+NUMBER_OF_HOURS: 10  # Number of hours to be taken from the input data
 
 #### Testing Related Parameters ####
 TEST_SCHEDULE: [2000, 100000]  # The frequency the model is actually tested.

--- a/configs/nocrash/resnet34imnet10S2.yaml
+++ b/configs/nocrash/resnet34imnet10S2.yaml
@@ -23,7 +23,7 @@ TRAIN_DATASET_NAME: 'CoILTrain'  # The name of the training dataset used. Must b
 AUGMENTATION: None  # The image augmentation applied on every input image
 DATA_USED: 'all'  # The part of the data to be used
 USE_NOISE_DATA: True  # If we use the noise data.
-NUMBER_OF_HOURS: 50  # Number of hours to be taken from the input data
+NUMBER_OF_HOURS: 10  # Number of hours to be taken from the input data
 
 #### Testing Related Parameters ####
 TEST_SCHEDULE: [2000, 100000]  # The frequency the model is actually tested.


### PR DESCRIPTION
# Description
This sets the number of training hours of the NoCrash models to correspond to the number of training hours as mentioned in the article "Exploring the Limitations of Behavior Cloning for Autonomous Driving."

# Where has this been tested?

    Platform(s): Linux
    Python version(s): 3.5

# Possible Drawbacks
n/a