### PR TITLE
Fix issue with parsing csv headers in the plotter.

### DIFF
--- a/plotter/plot_on_map.py
+++ b/plotter/plot_on_map.py
@@ -62,13 +62,10 @@ def split_episodes(meas_file):
     """
     f = open(meas_file, "rU")
     header_details = f.readline()
-
-    header_details = header_details.split(',')
-    header_details[-1] = header_details[-1][:-2]
+    header_details = [s.strip() for s in header_details.split(',')]
     f.close()
 
     print (header_details)
-
 
     details_matrix = np.loadtxt(open(meas_file, "rb"), delimiter=",", skiprows=1)
 
@@ -122,9 +119,7 @@ def get_causes_of_end(summary_file):
     """
     f = open(summary_file, "rU")
     header_summary = f.readline()
-
-    header_summary = header_summary.split(',')
-    header_summary[-1] = header_summary[-1][:-2]
+    header_summary = [s.strip() for s in header_summary.split(',')]
     f.close()
 
     summary_matrix = np.loadtxt(open(summary_file, "rb"), delimiter=",", skiprows=1)


### PR DESCRIPTION
# Description
Fixes an issue with parsing csv column header names in the plotter code. On my Linux machine, the last name in the header list had its last character stripped (e.g. `end_point` would be parsed as `end_poin`). This PR changes the parsing to use a more generic whitespace stripper.

The original code resulted in the following error:
```
Traceback (most recent call last):
  File "/home/thomas/code/autonomous-driving/carla/coiltraine/coil_core/run_drive.py", line 128, in driving_benchmark
    checkpoint_number, town_name, g_conf.PROCESS_NAME.split('_')[1])
  File "/home/thomas/code/autonomous-driving/carla/coiltraine/plotter/plot_on_map.py", line 170, in plot_episodes_tracks
    episodes_positions, travelled_distances = split_episodes(meas_file)
  File "/home/thomas/code/autonomous-driving/carla/coiltraine/plotter/plot_on_map.py", line 87, in split_episodes
    previous_end_point = details_matrix[0, header_details.index('end_point')]
ValueError: 'end_point' is not in list
```

# Where has this been tested?

    Platform(s): linux
    Python version(s): 3.5

# Possible Drawbacks
None.